### PR TITLE
Fix missing lines with multicolumn header

### DIFF
--- a/latextable.py
+++ b/latextable.py
@@ -181,14 +181,15 @@ def _draw_latex_header(table, drop_columns, use_booktabs, multicolumn_header):
 
     # Multicolumn header
     if multicolumn_header is not None:
-        multicolumn_header_str = [f"\\multicolumn{{count}}{'{|c|}' if idx == 1 else '{c|}'}{{}}".format(count, name)for idx, (name, count) in enumerate(multicolumn_header)]
+        multicolumn_header_str = [f"\\multicolumn{{{count}}}{'{|c|}' if idx == 0 else '{c|}'}{{{name}}}" for idx, (name, count) in enumerate(multicolumn_header)]
         out += _indent_text(" & ".join(multicolumn_header_str) + " \\\\\n", 3)
+        out += _indent_text("\\{}\n".format(rule), 3)
 
     # Normal header
     out += _indent_text(" & ".join(header) + " \\\\\n", 3)
 
     # Mid rule
-    if table._has_header() or mulicolumn_header is not None or use_booktabs:
+    if table._has_header() or use_booktabs:
         rule = 'midrule' if use_booktabs else 'hline'
         out += _indent_text("\\{}\n".format(rule), 3)
     return out

--- a/latextable.py
+++ b/latextable.py
@@ -181,14 +181,14 @@ def _draw_latex_header(table, drop_columns, use_booktabs, multicolumn_header):
 
     # Multicolumn header
     if multicolumn_header is not None:
-        multicolumn_header_str = ["\\multicolumn{{{:d}}}{{c}}{{{:s}}}".format(c, name) for name, c in multicolumn_header]
+        multicolumn_header_str = [f"\\multicolumn{{count}}{'{|c|}' if idx == 1 else '{c|}'}{{}}".format(count, name)for idx, (name, count) in enumerate(multicolumn_header)]
         out += _indent_text(" & ".join(multicolumn_header_str) + " \\\\\n", 3)
 
     # Normal header
     out += _indent_text(" & ".join(header) + " \\\\\n", 3)
 
     # Mid rule
-    if table._has_header() or use_booktabs:
+    if table._has_header() or mulicolumn_header is not None or use_booktabs:
         rule = 'midrule' if use_booktabs else 'hline'
         out += _indent_text("\\{}\n".format(rule), 3)
     return out


### PR DESCRIPTION
With a multicolumn header, there is no vertical lines on the row, nor is there a horizontal line below it. This is a simple change to add that.